### PR TITLE
Shorten wording in order submenu tab headers

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -8,9 +8,9 @@
   <% if checkout_steps.include?("address") %>
     <li class="tab <%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
       <% if can?(:update, @order) %>
-        <%= link_to_with_icon 'user', Spree.t(:customer_details), edit_admin_order_customer_url(@order) %>
+        <%= link_to_with_icon 'user', Spree.t(:customer), edit_admin_order_customer_url(@order) %>
       <% else %>
-        <%= link_to_with_icon 'user', Spree.t(:customer_details), admin_order_customer_url(@order) %>
+        <%= link_to_with_icon 'user', Spree.t(:customer), admin_order_customer_url(@order) %>
       <% end %>
     </li>
   <% end %>
@@ -40,7 +40,7 @@
   <% if can? :display, Spree::ReturnAuthorization %>
     <% if @order.completed? %>
       <li class="tab <%= "active" if current == "Return Authorizations" %>" data-hook='admin_order_tabs_return_authorizations'>
-        <%= link_to_with_icon 'share', Spree::ReturnAuthorization.model_name.human(count: :other), admin_order_return_authorizations_url(@order) %>
+        <%= link_to_with_icon 'share', Spree.t(:rma), admin_order_return_authorizations_url(@order) %>
       </li>
     <% end %>
   <% end %>

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -28,7 +28,7 @@ describe "Customer Details", type: :feature, js: true do
       end
       click_icon :plus
       expect(page).to have_css('.line-item')
-      click_link "Customer Details"
+      click_link "Customer"
       targetted_select2 "foobar@example.com", from: "#s2id_customer_search"
       # 5317 - Address prefills using user's default.
       expect(page).to have_field('First Name', with: user.bill_address.firstname)
@@ -61,7 +61,7 @@ describe "Customer Details", type: :feature, js: true do
       before { create(:country, iso: "BRA", name: "Brazil") }
 
       it "changes state field to text input" do
-        click_link "Customer Details"
+        click_link "Customer"
 
         within("#billing") do
           targetted_select2 "Brazil", from: "#s2id_order_bill_address_attributes_country_id"
@@ -70,7 +70,7 @@ describe "Customer Details", type: :feature, js: true do
 
         click_button "Update"
         expect(page).to have_content "Customer Details Updated"
-        click_link "Customer Details"
+        click_link "Customer"
         expect(page).to have_field("order_bill_address_attributes_state_name", with: "Piaui")
       end
     end
@@ -79,12 +79,12 @@ describe "Customer Details", type: :feature, js: true do
       order.ship_address = create(:address)
       order.save!
 
-      click_link "Customer Details"
+      click_link "Customer"
       within("#shipping") { fill_in_address "ship" }
       within("#billing") { fill_in_address "bill" }
 
       click_button "Update"
-      click_link "Customer Details"
+      click_link "Customer"
 
       # Regression test for https://github.com/spree/spree/issues/2950 and https://github.com/spree/spree/issues/2433
       # This act should transition the state of the order as far as it will go too
@@ -95,7 +95,7 @@ describe "Customer Details", type: :feature, js: true do
 
     it "should show validation errors" do
       order.update_attributes!(ship_address_id: nil)
-      click_link "Customer Details"
+      click_link "Customer"
       click_button "Update"
       expect(page).to have_content("Shipping address first name can't be blank")
     end
@@ -103,7 +103,7 @@ describe "Customer Details", type: :feature, js: true do
     it "updates order email for an existing order with a user" do
       order.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id, state: "confirm", completed_at: nil)
       previous_user = order.user
-      click_link "Customer Details"
+      click_link "Customer"
       fill_in "order_email", with: "newemail@example.com"
       expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
       expect(order.user_id).to eq previous_user.id
@@ -121,7 +121,7 @@ describe "Customer Details", type: :feature, js: true do
       end
 
       it "sets default country when displaying form" do
-        click_link "Customer Details"
+        click_link "Customer"
         expect(page).to have_field("order_bill_address_attributes_country_id", with: brazil.id)
       end
     end
@@ -133,7 +133,7 @@ describe "Customer Details", type: :feature, js: true do
       end
 
       specify do
-        click_link "Customer Details"
+        click_link "Customer"
         # Need to fill in valid information so it passes validations
         fill_in "order_ship_address_attributes_firstname",  with: "John 99"
         fill_in "order_ship_address_attributes_lastname",   with: "Doe"

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -29,7 +29,7 @@ describe "New Order", type: :feature do
     fill_in_quantity("table.stock-levels", "quantity_0", 2)
 
     click_icon :plus
-    click_on "Customer Details"
+    click_on "Customer"
 
     within "#select-customer" do
       targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -73,7 +73,7 @@ describe "New Order", type: :feature do
         expect(page).to have_content(product.name)
       end
 
-      click_on "Customer Details"
+      click_on "Customer"
 
       within "#select-customer" do
         targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -122,7 +122,7 @@ describe "New Order", type: :feature do
   # Regression test for https://github.com/spree/spree/issues/3336
   context "start by customer address" do
     it "completes order fine", js: true do
-      click_on "Customer Details"
+      click_on "Customer"
 
       within "#select-customer" do
         targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -165,7 +165,7 @@ describe "New Order", type: :feature do
 
       expect(page).to have_css('.line-item')
 
-      click_link "Customer Details"
+      click_link "Customer"
       targetted_select2 user.email, from: "#s2id_customer_search"
       click_button "Update"
       expect(Spree::Order.last.state).to eq 'delivery'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1487,6 +1487,7 @@ en:
     risk: Risk
     risk_analysis: Risk Analysis
     risky: Risky
+    rma: RMA
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value


### PR DESCRIPTION
This commit shortens the wording in the tab headers so that the default max container width will not force tabs to be in the dropdown.  We can consider going back to the more verbose wording once the restrictive grid system is changed. Adjust the tests for the new wording so that the links are proper.
